### PR TITLE
OLE-7956 - Added mandatory condition for copies if exist more than 1 for foreign vendor

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/select/document/validation/impl/OleValidationRuleBase.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/select/document/validation/impl/OleValidationRuleBase.java
@@ -349,6 +349,7 @@ public class OleValidationRuleBase extends AccountingRuleEngineRuleBase implemen
                 }
             }
         }
+        processCustomAddCopiesRequisitionBusinessRules(document, item);
         return result;
 
     }


### PR DESCRIPTION
OLE-7956 - Added mandatory condition for copies if exist more than 1 for foreign vendor