### PR TITLE
Component Capitalization Fix

### DIFF
--- a/ole-docstore/ole-docstore-engine/src/main/java/org/kuali/ole/docstore/engine/service/storage/DocstoreRDBMSStorageService.java
+++ b/ole-docstore/ole-docstore-engine/src/main/java/org/kuali/ole/docstore/engine/service/storage/DocstoreRDBMSStorageService.java
@@ -369,7 +369,7 @@ public class DocstoreRDBMSStorageService implements DocstoreStorageService {
     public void processBibTrees(BibTrees bibTrees) {
         List<Future> futures = new ArrayList<>();
         String parameter = ParameterValueResolver.getInstance().getParameter("OLE", "OLE-DESC",
-                "DESCRIBE", "NUM_THREADS_FOR_PROCESSING_BIB");
+                "Describe", "NUM_THREADS_FOR_PROCESSING_BIB");
         OleStopWatch oleStopWatch = new OleStopWatch();
         LOG.info("NUM_THREADS_FOR_PROCESSING_BIB: " + parameter);
         ExecutorService executorService = Executors.newFixedThreadPool(StringUtils.isNotEmpty(parameter) ? Integer


### PR DESCRIPTION
This commit changes the CMPNT_CD from 'DESCRIBE' to 'Describe' when
reading the 'NUM_THREADS_FOR_PROCESSING_BIB' from the database. The
name with only the first letter capitalized matches the convention used
elsewhere in the code.

Closes OLEFDBK-2667