### PR TITLE
OLE-8545 	Stack trace error on SearchWorkbench - when no results found

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/describe/controller/OLESearchController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/describe/controller/OLESearchController.java
@@ -897,7 +897,11 @@ public class OLESearchController extends UifControllerBase {
       if( oleSearchForm.getSearchResponse() !=null){
           this.totalRecCount = oleSearchForm.getSearchResponse().getTotalRecordCount();
           this.start = oleSearchForm.getSearchResponse().getStartIndex();
+      }else{
+          this.totalRecCount = 0;
+          this.start = 0;
       }
+
         this.pageSize = oleSearchForm.getPageSize();
         oleSearchForm.setPreviousFlag(getPreviousFlag());
         oleSearchForm.setNextFlag(getNextFlag());


### PR DESCRIPTION
This is to make page size and total number records as Zero