### PR TITLE
OLE-8457 Deliver requests need to use ITEM_ID as unique identifier for item records instead of barcode

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/bo/OLEDeliverRequestResultDisplayRow.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/bo/OLEDeliverRequestResultDisplayRow.java
@@ -12,6 +12,7 @@ public class OLEDeliverRequestResultDisplayRow {
     private String requestTypeCode;
     private String borrowerFirstName;
     private String borrowerLastName;
+    private String itemUuid;
     private String borrowerBarcode;
     private Date createDate;
     private Date expiryDate;
@@ -60,6 +61,14 @@ public class OLEDeliverRequestResultDisplayRow {
 
     public String getBorrowerBarcode() {
         return borrowerBarcode;
+    }
+
+    public String getItemUuid() {
+        return itemUuid;
+    }
+
+    public void setItemUuid(String itemUuid) {
+        this.itemUuid = itemUuid;
     }
 
     public void setBorrowerBarcode(String borrowerBarcode) {

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/bo/OLEItemSearchResultDisplayRow.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/bo/OLEItemSearchResultDisplayRow.java
@@ -10,6 +10,7 @@ public class OLEItemSearchResultDisplayRow {
     private String itemType;
     private String itemStatus;
     private String itemBarCode;
+    private String itemUUID;
     private String enumeration;
     private String callNumber;
     private String chronology;
@@ -56,6 +57,14 @@ public class OLEItemSearchResultDisplayRow {
 
     public void setItemBarCode(String itemBarCode) {
         this.itemBarCode = itemBarCode;
+    }
+
+    public String getItemUUID() {
+        return itemUUID;
+    }
+
+    public void setItemUUID(String itemUUID) {
+        this.itemUUID = itemUUID;
     }
 
     public String getEnumeration() {

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/lookup/OleItemSearchLookupableImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/lookup/OleItemSearchLookupableImpl.java
@@ -87,7 +87,7 @@ public class OleItemSearchLookupableImpl extends OleLookupableImpl {
         String callNumber = searchCriteria.get("callNumber") != null ? searchCriteria.get("callNumber") : "";
         String itemType = searchCriteria.get("itemType") != null ? searchCriteria.get("itemType") : "";
         String itemBarCode = searchCriteria.get("itemBarCode") != null ? searchCriteria.get("itemBarCode") : "";
-        // String itemUuid = searchCriteria.get("itemUuid") != null ? searchCriteria.get("itemUuid") : "";
+        String itemUUID = searchCriteria.get("itemUUID") != null ? searchCriteria.get("itemUUID") : "";
         String pageDisplay = searchCriteria.get("pageDisplay") != null ? searchCriteria.get("pageDisplay") : "";
         String page_Size = searchCriteria.get("pageSize") != null ? searchCriteria.get("pageSize") : "";
 
@@ -146,9 +146,9 @@ public class OleItemSearchLookupableImpl extends OleLookupableImpl {
                 if (!itemBarCode.isEmpty()) {
                     item_search_Params.getSearchConditions().add(item_search_Params.buildSearchCondition("phrase", item_search_Params.buildSearchField(DocType.ITEM.getCode(), Item.ITEM_BARCODE, itemBarCode), "AND"));
                 }
-                /*if (!itemUuid.isEmpty()) {
-                    item_search_Params.getSearchConditions().add(item_search_Params.buildSearchCondition("AND", item_search_Params.buildSearchField(DocType.ITEM.getCode(), Item.ID, itemUuid), "AND"));
-                }*/
+                if (!itemUUID.isEmpty()) {
+                    item_search_Params.getSearchConditions().add(item_search_Params.buildSearchCondition("AND", item_search_Params.buildSearchField(DocType.ITEM.getCode(), Item.ID, itemUUID), "AND"));
+                }
                 getDocstoreUtil().getSearchResultFields(item_search_Params);
                 SearchResponse searchResponse = getDocstoreClientLocator().getDocstoreClient().search(item_search_Params);
                 this.totalRecCount = searchResponse.getTotalRecordCount();

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OLEDeliverItemSearchView.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OLEDeliverItemSearchView.xml
@@ -450,6 +450,7 @@
                 <bean id="firstNameItemPlaceRequest" parent="Uif-DataField" p:label="First Name" p:propertyName="borrowerFirstName"/>
                 <bean id="lastNameItemPlaceRequest" parent="Uif-DataField" p:label="Last Name" p:propertyName="borrowerLastName"/>
                 <bean id="barcodeItemPlaceRequest" parent="Uif-DataField" p:label="Barcode" p:propertyName="borrowerBarcode"/>
+                <bean id="itemIdPlaceRequest" parent="Uif-DataField" p:label="Item Id" p:propertyName="itemUuid"/>
                 <bean id="createDateItemPlaceRequest" parent="Uif-DataField" p:label="Create Date" p:propertyName="createDate"/>
                 <bean id="expirationDateItemPlaceRequest" parent="Uif-DataField" p:label="Request Expiration Date" p:propertyName="expiryDate"/>
                 <bean id="onHoldExpirationDateItemPlaceRequest" parent="Uif-DataField" p:label="On Hold Expiration Date" p:propertyName="onHoldExpirationDate"/>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OleDeliverRequestDocument.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OleDeliverRequestDocument.xml
@@ -31,6 +31,7 @@
                 <ref bean="OleRequestDocument-modifiedDate"/>
 
                 <ref bean="OleRequestDocument-title"/>
+                <ref bean="OleRequestDocument-itemUuid"/>
                 <ref bean="OleRequestDocument-author"/>
                 <ref bean="OleRequestDocument-shelvingLocation"/>
                 <ref bean="OleRequestDocument-callNumber"/>
@@ -417,6 +418,20 @@
         <property name="label" value="Title"/>
     </bean>
 
+    <bean id="OleRequestDocument-itemUuid" parent="OleRequestDocument-itemUuid-parentBean"/>
+
+    <bean id="OleRequestDocument-itemUuid-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="itemUuid"/>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="30"/>
+        </property>
+        <property name="controlField">
+            <bean parent="Uif-TextControl" p:size="30"/>
+        </property>
+        <property name="forceUppercase" value="false"/>
+        <property name="label" value="Item Id"/>
+    </bean>
+
 
     <bean id="OleRequestDocument-author" parent="OleRequestDocument-author-parentBean"/>
 
@@ -606,10 +621,11 @@
                 <bean id="itemId" parent="Uif-LookupCriteriaInputField" p:propertyName="itemId" p:label="Item Barcode">
                     <property name="quickfinder">
                         <bean parent="Uif-QuickFinder" p:dataObjectClassName="org.kuali.ole.deliver.bo.OleItemSearch"
-                              p:fieldConversions="itemBarCode:itemId,title:title" p:lookupParameters="itemId:itemBarCode,title:title"/>
+                              p:fieldConversions="itemBarCode:itemId,title:title,itemUUID:itemUuid" p:lookupParameters="itemId:itemBarCode,title:title,itemUuid:itemUUID"/>
                     </property>
                 </bean>
                 <bean id="title" parent="Uif-LookupCriteriaInputField" p:propertyName="title" p:label="Item Title"/>
+                <bean id="itemUuid" parent="Uif-LookupCriteriaInputField" p:propertyName="itemUuid" p:label="Item Id"/>
             </list>
         </property>
         <property name="additionalScriptFiles">
@@ -627,6 +643,7 @@
                 <bean id="result-itemBarcode" parent="Uif-DataField" p:propertyName="itemId" />
                 <bean id="result-itemType" parent="Uif-DataField" p:propertyName="itemType" p:label="Item Type"/>
                 <bean id="result-title" parent="Uif-DataField" p:propertyName="title" />
+                <bean id="result-itemUuid" parent="Uif-DataField" p:propertyName="itemUuid" />
                 <bean id="result-author" parent="Uif-DataField" p:propertyName="author" />
                 <bean id="result-callNumber" parent="Uif-DataField" p:propertyName="callNumber" />
                 <bean id="result-itemStatus" parent="Uif-DataField" p:propertyName="itemStatus" p:label="Item Status"/>
@@ -838,6 +855,7 @@
 
                 <bean id="recallInquiryRequest-borrowerQueuePosition" parent="Uif-InputField" p:propertyName="borrowerQueuePosition"/>
                 <bean id="recallInquiryRequest-itemId" parent="Uif-InputField" p:propertyName="itemId"/>
+                <bean id="recallInquiryRequest-itemUuid" parent="Uif-InputField" p:propertyName="itemUuid"/>
                 <bean id="recallInquiryRequest-title" parent="Uif-InputField" p:propertyName="title"/>
                 <bean id="recallInquiryRequest-author" parent="Uif-InputField" p:propertyName="author"/>
                 <bean id="recallInquiryRequest-shelvingLocation" parent="Uif-InputField" p:propertyName="shelvingLocation"/>
@@ -865,6 +883,7 @@
 
                 <bean id="onHoldInquiryRequest-borrowerQueuePosition" parent="Uif-InputField" p:propertyName="borrowerQueuePosition"/>
                 <bean id="onHoldInquiryRequest-itemId" parent="Uif-InputField" p:propertyName="itemId"/>
+                <bean id="onHoldInquiryRequest-itemUuid" parent="Uif-InputField" p:propertyName="itemUuid"/>
                 <bean id="onHoldInquiryRequest-title" parent="Uif-InputField" p:propertyName="title"/>
                 <bean id="onHoldInquiryRequest-author" parent="Uif-InputField" p:propertyName="author"/>
                 <bean id="onHoldInquiryRequest-shelvingLocation" parent="Uif-InputField" p:propertyName="shelvingLocation"/>
@@ -891,6 +910,7 @@
             <list>
                 <bean id="pageInquiryRequest-borrowerQueuePosition" parent="Uif-InputField" p:propertyName="borrowerQueuePosition"/>
                 <bean id="pageInquiryRequest-select-itemId" parent="Uif-InputField" p:propertyName="itemId"/>
+                <bean id="pageInquiryRequest-itemUuid" parent="Uif-InputField" p:propertyName="itemUuid"/>
                 <bean id="pageInquiryRequest-itemId" parent="Uif-InputField" p:propertyName="title"/>
                 <bean id="pageRequest-inquiryItemDetails-author"  parent="Uif-InputField" p:propertyName="author"/>
                 <bean id="pageRequest-inquiryItemDetails-shelvingLocation"  parent="Uif-InputField" p:propertyName="shelvingLocation"/>
@@ -917,6 +937,7 @@
         <property name="items">
             <list>
                 <bean id="copyInquiryRequest-select-itemId" parent="Uif-InputField" p:propertyName="itemId"/>
+                <bean id="copyInquiryRequest-itemUuid" parent="Uif-InputField" p:propertyName="itemUuid"/>
                 <bean id="copyInquiryRequest-itemId" parent="Uif-InputField" p:propertyName="title"/>
                 <bean id="copyInquiryRequest-borrowerQueuePosition" parent="Uif-InputField" p:propertyName="borrowerQueuePosition"/>
                 <bean id="copyInquiryRequest-pickupLocation" parent="Uif-InputField" p:propertyName="pickUpLocationCode" p:label="Pickup Location"/>
@@ -943,6 +964,7 @@
             <list>
                 <bean id="inTransitInquiryRequest-borrowerQueuePosition" parent="Uif-InputField" p:propertyName="borrowerQueuePosition"/>
                 <bean id="inTransitInquiryRequest-select-itemId" parent="Uif-InputField" p:propertyName="itemId"/>
+                <bean id="inTransitInquiryRequest-itemUuid" parent="Uif-InputField" p:propertyName="itemUuid"/>
                 <bean id="inTransitInquiryRequest-itemId" parent="Uif-InputField" p:propertyName="title"/>
                 <bean id="inTransitInquiryRequest-author" parent="Uif-InputField" p:propertyName="author"/>
                 <bean id="inTransitInquiryRequest-shelvingLocation" parent="Uif-InputField" p:propertyName="shelvingLocation"/>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OleDeliverRequestSearch.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OleDeliverRequestSearch.xml
@@ -64,7 +64,7 @@
         </property>
     </bean>
     <bean id="RequestSearchSection-HorizontalBoxSection" parent="RequestSearchSection-HorizontalBoxSection-parentBean" />
-    <bean id="RequestSearchSection-HorizontalBoxSection-parentBean" parent="Uif-TableCollectionSection" p:layoutManager.numberOfColumns="14">
+    <bean id="RequestSearchSection-HorizontalBoxSection-parentBean" parent="Uif-TableCollectionSection" p:layoutManager.numberOfColumns="15">
         <property name="collectionObjectClass" value="org.kuali.ole.deliver.bo.OleDeliverRequestBo"/>
         <property name="propertyName" value="deliverRequestBos"/>
         <property name="layoutManager.renderSequenceField" value="false"/>
@@ -80,6 +80,8 @@
                 <bean id="borrowerQueuePosition" parent="Uif-InputField" p:label="Queue Position" p:propertyName="borrowerQueuePosition">
                 </bean>
                 <bean id="itemBarcode" parent="Uif-DataField" p:propertyName="oleItemSearch.itemBarCode" p:label="Item Barcode" >
+                </bean>
+                <bean id="itemUuid" parent="Uif-DataField" p:propertyName="oleItemSearch.itemUUID" p:label="Item Id" >
                 </bean>
                 <bean id="itemTitle" parent="Uif-DataField" p:propertyName="oleItemSearch.title" p:label="Title" >
                 </bean>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OleItemSearch.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OleItemSearch.xml
@@ -29,6 +29,7 @@
         <ref bean="OleItemSearch-publisher"/>
         <ref bean="OleItemSearch-itemType"/>
         <ref bean="OleItemSearch-callNumber"/>
+        <ref bean="OleItemSearch-itemUUID"/>
         <ref bean="OleItemSearch-shelvingLocation"/>
         <ref bean="OleItemSearch-itemStatus"/>
         <ref bean="OleItemSearch-copyNumber"/>
@@ -117,23 +118,42 @@
   </bean>
 
 
-   <bean id="OleItemSearch-itemBarCode" parent="OleItemSearch-itemBarCode-parentBean"/>
+    <bean id="OleItemSearch-itemBarCode" parent="OleItemSearch-itemBarCode-parentBean"/>
 
-  <bean id="OleItemSearch-itemBarCode-parentBean" abstract="true" parent="AttributeDefinition">
-    <property name="forceUppercase" value="false"/>
-    <property name="shortLabel" value="Item Barcode"/>
-    <property name="maxLength" value="30"/>
-    <property name="control">
-      <bean  id="TextControlDefinition_ItemBarCode" parent="TextControlDefinition" p:size="30"/>
-    </property>
-    <property name="controlField">
-      <bean id="Uif-TextControl_ItemBarcode" parent="Uif-TextControl" p:size="30"/>
-    </property>
-    <property name="name" value="itemBarCode"/>
-    <property name="label" value="Item Barcode"/>
-    <property name="description" value="Item Barcode"/>
+    <bean id="OleItemSearch-itemBarCode-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="forceUppercase" value="false"/>
+        <property name="shortLabel" value="Item Barcode"/>
+        <property name="maxLength" value="30"/>
+        <property name="control">
+            <bean  id="TextControlDefinition_ItemBarCode" parent="TextControlDefinition" p:size="30"/>
+        </property>
+        <property name="controlField">
+            <bean id="Uif-TextControl_ItemBarcode" parent="Uif-TextControl" p:size="30"/>
+        </property>
+        <property name="name" value="itemBarCode"/>
+        <property name="label" value="Item Barcode"/>
+        <property name="description" value="Item Barcode"/>
 
-  </bean>
+    </bean>
+
+    <bean id="OleItemSearch-itemUUID" parent="OleItemSearch-itemUUID-parentBean"/>
+
+    <bean id="OleItemSearch-itemUUID-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="forceUppercase" value="false"/>
+        <property name="shortLabel" value="Item Id"/>
+        <property name="maxLength" value="30"/>
+        <property name="control">
+            <bean  id="TextControlDefinition_ItemUUID" parent="TextControlDefinition" p:size="40"/>
+        </property>
+        <property name="controlField">
+            <bean id="Uif-TextControl_ItemUUID" parent="Uif-TextControl" p:size="40"/>
+        </property>
+        <property name="name" value="itemUUID"/>
+        <property name="label" value="Item Id"/>
+        <property name="description" value="Item Id"/>
+
+    </bean>
+
 
     <bean id="OleItemSearch-publisher" parent="OleItemSearch-publisher-parentBean"/>
 
@@ -200,6 +220,7 @@
                 <bean id="title" parent="Uif-LookupCriteriaInputField" p:propertyName="title"/>
                 <bean id="author" parent="Uif-LookupCriteriaInputField" p:propertyName="author" />
                 <bean id="itemBarCode" parent="Uif-LookupCriteriaInputField" p:propertyName="itemBarCode" />
+                <bean id="itemUUID" parent="Uif-LookupCriteriaInputField" p:propertyName="itemUUID" />
                 <bean id="publisher" parent="Uif-LookupCriteriaInputField" p:propertyName="publisher"/>
                 <bean id="itemType" parent="Uif-LookupCriteriaInputField" p:propertyName="itemType"/>
                 <bean id="callNumber" parent="Uif-LookupCriteriaInputField" p:propertyName="callNumber"/>
@@ -211,6 +232,7 @@
                 <bean id="result_title" parent="Uif-DataField" p:propertyName="title" />
                 <bean id="result_author" parent="Uif-DataField" p:propertyName="author" />
                 <bean id="result_itemBarCode" parent="Uif-DataField" p:propertyName="itemBarCode" />
+                <bean id="result_itemUUID" parent="Uif-DataField" p:propertyName="itemUUID" />
                 <bean id="result_publisher" parent="Uif-DataField" p:propertyName="publisher" />
                 <bean id="result_itemType" parent="Uif-DataField" p:propertyName="itemType" />
                 <bean id="result_callNumber" parent="Uif-DataField" p:propertyName="callNumber" />

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/document/OleDeliverRequestMaintenanceDocument.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/document/OleDeliverRequestMaintenanceDocument.xml
@@ -452,50 +452,54 @@
                       p:render="@{document.newMaintainableObject.dataObject.requestCreator eq 'Proxy Patron' }"/>
 
 
-                <bean id="RecallRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:required="true" p:readOnly="@{maintenanceAction eq 'Edit' }"
+                <bean id="RecallRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:readOnly="@{maintenanceAction eq 'Edit' }"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '1' or document.oldMaintainableObject.dataObject.requestTypeId eq '1' or document.newMaintainableObject.dataObject.requestTypeId eq '2' or document.oldMaintainableObject.dataObject.requestTypeId eq '2'}">
                     <property name="quickfinder">
                         <bean parent="Uif-QuickFinder" p:dataObjectClassName="org.kuali.ole.deliver.bo.OleItemSearch" p:readOnly="@{maintenanceAction eq 'Edit' }"
                               p:fieldConversions="itemBarCode:itemId,author:author,title:title,callNumber:callNumber,copyNumber:copyNumber,shelvingLocation:shelvingLocation,itemStatus:itemStatus,itemUUID:itemUuid,chronology:chronology,enumeration:enumeration"
-                              p:lookupParameters="itemId:itemBarCode,title:title"/>
+                              p:lookupParameters="itemId:itemBarCode,title:title,itemUuid:itemUUID"/>
                     </property>
                 </bean>
-                <bean id="OnholdRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:required="true" p:readOnly="@{maintenanceAction eq 'Edit' }"
+                <bean id="OnholdRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:readOnly="@{maintenanceAction eq 'Edit' }"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '3' or document.oldMaintainableObject.dataObject.requestTypeId eq '3' or document.newMaintainableObject.dataObject.requestTypeId eq '4' or document.oldMaintainableObject.dataObject.requestTypeId eq '4' or document.newMaintainableObject.dataObject.requestTypeId eq '9' or document.oldMaintainableObject.dataObject.requestTypeId eq '9'}">
                     <property name="quickfinder">
                         <bean parent="Uif-QuickFinder" p:dataObjectClassName="org.kuali.ole.deliver.bo.OleItemSearch"
                               p:fieldConversions="itemBarCode:itemId,author:author,title:title,callNumber:callNumber,copyNumber:copyNumber,shelvingLocation:shelvingLocation,itemStatus:itemStatus,itemUUID:itemUuid,chronology:chronology,enumeration:enumeration"
-                              p:lookupParameters="itemId:itemBarCode,title:title"/>
+                              p:lookupParameters="itemId:itemBarCode,title:title,itemUuid:itemUUID"/>
                     </property>
                 </bean>
-                <bean id="TransitRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:required="true" p:readOnly="@{maintenanceAction eq 'Edit' }"
+                <bean id="TransitRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:readOnly="@{maintenanceAction eq 'Edit' }"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '8' or document.oldMaintainableObject.dataObject.requestTypeId eq '8'}">
                     <property name="quickfinder">
                         <bean parent="Uif-QuickFinder" p:dataObjectClassName="org.kuali.ole.deliver.bo.OleItemSearch"
                               p:fieldConversions="itemBarCode:itemId,author:author,title:title,callNumber:callNumber,copyNumber:copyNumber,shelvingLocation:shelvingLocation,itemStatus:itemStatus,itemUUID:itemUuid,chronology:chronology,enumeration:enumeration"
-                              p:lookupParameters="itemId:itemBarCode,title:title"/>
+                              p:lookupParameters="itemId:itemBarCode,title:title,itemUuid:itemUUID"/>
                     </property>
                 </bean>
-                <bean id="CopyRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:required="true" p:readOnly="@{maintenanceAction eq 'Edit' }"
+                <bean id="CopyRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:readOnly="@{maintenanceAction eq 'Edit' }"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '7' or document.oldMaintainableObject.dataObject.requestTypeId eq '7'}">
                     <property name="quickfinder">
                         <bean parent="Uif-QuickFinder" p:dataObjectClassName="org.kuali.ole.deliver.bo.OleItemSearch"
                               p:fieldConversions="itemBarCode:itemId,author:author,title:title,callNumber:callNumber,copyNumber:copyNumber,shelvingLocation:shelvingLocation,itemStatus:itemStatus,itemUUID:itemUuid,chronology:chronology,enumeration:enumeration"
-                              p:lookupParameters="itemId:itemBarCode,title:title"/>
+                              p:lookupParameters="itemId:itemBarCode,title:title,itemUuid:itemUUID"/>
                     </property>
                 </bean>
-                <bean id="PageRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:required="true" p:readOnly="@{maintenanceAction eq 'Edit' }"
+                <bean id="PageRequest-itemId" parent="Uif-InputField" p:propertyName="itemId" p:readOnly="@{maintenanceAction eq 'Edit' }"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '5' or document.oldMaintainableObject.dataObject.requestTypeId eq '5' or document.newMaintainableObject.dataObject.requestTypeId eq '6' or document.oldMaintainableObject.dataObject.requestTypeId eq '6'}">
                     <property name="quickfinder">
                         <bean parent="Uif-QuickFinder" p:dataObjectClassName="org.kuali.ole.deliver.bo.OleItemSearch"
                               p:fieldConversions="itemBarCode:itemId,author:author,title:title,callNumber:callNumber,copyNumber:copyNumber,shelvingLocation:shelvingLocation,itemStatus:itemStatus,itemUUID:itemUuid,chronology:chronology,enumeration:enumeration"
-                              p:lookupParameters="itemId:itemBarCode,title:title"/>
+                              p:lookupParameters="itemId:itemBarCode,title:title,itemUuid:itemUUID"/>
                     </property>
                 </bean>
 
                 <bean id="recallRequest-itemTitle" parent="Uif-InputField" p:propertyName="title"
                       p:readOnly="@{document.newMaintainableObject.dataObject.itemId ne null and (document.newMaintainableObject.dataObject.itemId ne null and document.newMaintainableObject.dataObject.itemId ne '')}"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '1' or document.oldMaintainableObject.dataObject.requestTypeId eq '1' or document.newMaintainableObject.dataObject.requestTypeId eq '2' or document.oldMaintainableObject.dataObject.requestTypeId eq '2' or document.newMaintainableObject.dataObject.requestTypeId eq '3' or document.oldMaintainableObject.dataObject.requestTypeId eq '3' or document.newMaintainableObject.dataObject.requestTypeId eq '4' or document.oldMaintainableObject.dataObject.requestTypeId eq '4' or document.newMaintainableObject.dataObject.requestTypeId eq '5' or document.oldMaintainableObject.dataObject.requestTypeId eq '5' or document.newMaintainableObject.dataObject.requestTypeId eq '6' or document.oldMaintainableObject.dataObject.requestTypeId eq '6' or document.newMaintainableObject.dataObject.requestTypeId eq '7' or document.oldMaintainableObject.dataObject.requestTypeId eq '7' or document.newMaintainableObject.dataObject.requestTypeId eq '8' or document.oldMaintainableObject.dataObject.requestTypeId eq '8' or document.newMaintainableObject.dataObject.requestTypeId eq '9' or document.oldMaintainableObject.dataObject.requestTypeId eq '9'}"/>
+                <bean id="recallRequest-itemUuid" parent="Uif-InputField" p:propertyName="itemUuid" p:required="true"
+                      p:readOnly="@{document.newMaintainableObject.dataObject.itemUuid ne null and (document.newMaintainableObject.dataObject.itemUuid ne null and document.newMaintainableObject.dataObject.itemUuid ne '')}"
+                      p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '1' or document.oldMaintainableObject.dataObject.requestTypeId eq '1' or document.newMaintainableObject.dataObject.requestTypeId eq '2' or document.oldMaintainableObject.dataObject.requestTypeId eq '2' or document.newMaintainableObject.dataObject.requestTypeId eq '3' or document.oldMaintainableObject.dataObject.requestTypeId eq '3' or document.newMaintainableObject.dataObject.requestTypeId eq '4' or document.oldMaintainableObject.dataObject.requestTypeId eq '4' or document.newMaintainableObject.dataObject.requestTypeId eq '5' or document.oldMaintainableObject.dataObject.requestTypeId eq '5' or document.newMaintainableObject.dataObject.requestTypeId eq '6' or document.oldMaintainableObject.dataObject.requestTypeId eq '6' or document.newMaintainableObject.dataObject.requestTypeId eq '7' or document.oldMaintainableObject.dataObject.requestTypeId eq '7' or document.newMaintainableObject.dataObject.requestTypeId eq '8' or document.oldMaintainableObject.dataObject.requestTypeId eq '8' or document.newMaintainableObject.dataObject.requestTypeId eq '9' or document.oldMaintainableObject.dataObject.requestTypeId eq '9'}"/>
+
                 <bean id="recallRequest-author" parent="Uif-InputField" p:propertyName="author"
                       p:readOnly="@{document.newMaintainableObject.dataObject.itemId ne null and (document.newMaintainableObject.dataObject.itemId ne null and document.newMaintainableObject.dataObject.itemId ne '')}"
                       p:render="@{document.newMaintainableObject.dataObject.requestTypeId eq '1' or document.oldMaintainableObject.dataObject.requestTypeId eq '1' or document.newMaintainableObject.dataObject.requestTypeId eq '2' or document.oldMaintainableObject.dataObject.requestTypeId eq '2' or document.newMaintainableObject.dataObject.requestTypeId eq '3' or document.oldMaintainableObject.dataObject.requestTypeId eq '3' or document.newMaintainableObject.dataObject.requestTypeId eq '4' or document.oldMaintainableObject.dataObject.requestTypeId eq '4' or document.newMaintainableObject.dataObject.requestTypeId eq '5' or document.oldMaintainableObject.dataObject.requestTypeId eq '5' or document.newMaintainableObject.dataObject.requestTypeId eq '6' or document.oldMaintainableObject.dataObject.requestTypeId eq '6' or document.newMaintainableObject.dataObject.requestTypeId eq '7' or document.oldMaintainableObject.dataObject.requestTypeId eq '7' or document.newMaintainableObject.dataObject.requestTypeId eq '8' or document.oldMaintainableObject.dataObject.requestTypeId eq '8' or document.newMaintainableObject.dataObject.requestTypeId eq '9' or document.oldMaintainableObject.dataObject.requestTypeId eq '9'}"/>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/uif/OleItemSearchLookup.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/uif/OleItemSearchLookup.xml
@@ -122,6 +122,7 @@
                 <bean parent="Uif-DataField" p:propertyName="author"/>
                 <bean parent="Uif-DataField" p:propertyName="publisher"/>
                 <bean parent="Uif-DataField" p:propertyName="itemBarCode"/>
+                <bean parent="Uif-DataField" p:propertyName="itemUUID"/>
                 <bean parent="Uif-DataField" p:propertyName="itemType"/>
                 <bean parent="Uif-DataField" p:propertyName="shelvingLocation"/>
                 <bean parent="Uif-DataField" p:propertyName="itemStatus"/>


### PR DESCRIPTION
OLE-8457
Deliver requests need to use ITEM_ID as unique identifier for item records instead of barcode