### PR TITLE
OLE-7844 : Uploading txt file in non-ANSI format via a Purchase Order Bulk Amendment document causes stack trace

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/select/document/service/impl/OLEPurchaseOrderBatchServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/select/document/service/impl/OLEPurchaseOrderBatchServiceImpl.java
@@ -1,5 +1,6 @@
 package org.kuali.ole.select.document.service.impl;
 
+import com.google.common.base.CharMatcher;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -492,15 +493,15 @@ public class OLEPurchaseOrderBatchServiceImpl implements OLEPurchaseOrderBatchSe
         String fileDirectory = getPOBACSVDirectory();
         File fileName = new File(fileDirectory + fileSeparator + OLEConstants.POBA_DIRECTORY + fileSeparator + olePurchaseOrderBatchDocument.getDocIdIngestFile().getOriginalFilename());
         BufferedWriter documentOut = new BufferedWriter(new FileWriter(fileName));
-        String documentFileContent = new String(olePurchaseOrderBatchDocument.getDocIdIngestFile().getBytes());
+        String documentFileContent = new String(olePurchaseOrderBatchDocument.getDocIdIngestFile().getBytes(),"UTF-8");
         documentOut.write(documentFileContent);
         documentOut.close();
         BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(fileName), "UTF-8"));
-       // BufferedReader br = new BufferedReader(new FileReader(fileName));
         String text = null;
         List<String> poIds = new ArrayList<String>();
         while ((text = br.readLine()) != null) {
             if (StringUtils.isNotEmpty(text)) {
+                text = CharMatcher.ASCII.retainFrom(text);
                 poIds.add(text);
             }
         }


### PR DESCRIPTION
OLE-7844 : Uploading txt file in non-ANSI format via a Purchase Order Bulk Amendment document causes stack trace
