### PR TITLE
OLE-8448 : Increased the file uploading size from 100MB to 500 MB for Krad controller for both Olefs and Docstore.

### DIFF
--- a/ole-app/olefs/src/main/webapp/WEB-INF/ole-krad-servlet.xml
+++ b/ole-app/olefs/src/main/webapp/WEB-INF/ole-krad-servlet.xml
@@ -135,7 +135,7 @@
         class="org.kuali.rice.krad.web.bind.UifConfigurableWebBindingInitializer"/>
 
     <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-    <property name="maxUploadSize" value="100000000"/>
+    <property name="maxUploadSize" value="500000000"/>
     </bean>
 
     <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">

--- a/ole-docstore/ole-docstore-webapp/src/main/webapp/WEB-INF/ole-docstore-krad-servlet.xml
+++ b/ole-docstore/ole-docstore-webapp/src/main/webapp/WEB-INF/ole-docstore-krad-servlet.xml
@@ -118,7 +118,7 @@
         class="org.kuali.rice.krad.web.bind.UifConfigurableWebBindingInitializer"/>
 
   <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-    <property name="maxUploadSize" value="500000"/>
+    <property name="maxUploadSize" value="500000000"/>
   </bean>
 
   <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">


### PR DESCRIPTION
OLE-8448 : Increased the file uploading size from 100MB to 500 MB for Krad controller for both Olefs and Docstore.
