### PR TITLE
OLE-8846: Fix so that Tomcat can also run under Java 8 = JDK 1.8.

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/OleDeliverRequestDocumentHelperServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/OleDeliverRequestDocumentHelperServiceImpl.java
@@ -116,7 +116,7 @@ public class OleDeliverRequestDocumentHelperServiceImpl {
     private OleCirculationPolicyService oleCirculationPolicyService;
     private DateTimeService dateTimeService;
     private List<OleLoanDocument> laonDocumentsFromLaondId;
-    private OlePatronHelperServiceImpl olePatronHelperService;
+    private OlePatronHelperService olePatronHelperService;
     private CircDeskLocationResolver circDeskLocationResolver;
     private OleLoanDocumentsFromSolrBuilder oleLoanDocumentsFromSolrBuilder;
     private ParameterValueResolver parameterResolverInstance;
@@ -196,7 +196,7 @@ public class OleDeliverRequestDocumentHelperServiceImpl {
         return olePatronHelperService;
     }
 
-    public void setOlePatronHelperService(OlePatronHelperServiceImpl olePatronHelperService) {
+    public void setOlePatronHelperService(OlePatronHelperService olePatronHelperService) {
         this.olePatronHelperService = olePatronHelperService;
     }
 


### PR DESCRIPTION
Cherry-pick #579 from develop to 2.1:
OLE-8819: match setter and getter for OlePatronHelperService
