### PR TITLE
OLE-6996 : operators need to be able to view circulation history of an item, including all previous borrowers stored in OLE

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/bo/OLESingleItemResultDisplayRow.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/bo/OLESingleItemResultDisplayRow.java
@@ -27,6 +27,7 @@ public class OLESingleItemResultDisplayRow {
     private String author;
     private String publication;
     private String itemStatusDate;
+    private Timestamp lastBorrowerItemStatusDate;
     private String dueDate;
     private String noOfPieces;
     private String holdingsLocation;
@@ -43,12 +44,18 @@ public class OLESingleItemResultDisplayRow {
 
     private String currentBorrowerId;
     private String patronBarcode;
+    private String lastBorrowerType;
+    private String lastBorrowerExpDate;
     private String patronType;
     private String patronExpDate;
     private String patronFirstName;
     private String patronMiddleName;
     private String patronLastName;
+    private String lastBorrowerFirstName;
+    private String lastBorrowerMiddleName;
+    private String lastBorrowerLastName;
     private String patronURL;
+    private String lastBorrowerURL;
     private String proxyBorrowerId;
     private String proxyPatronBarcode;
     private String proxyPatronName;
@@ -577,5 +584,61 @@ public class OLESingleItemResultDisplayRow {
 
     public void setCreateDate(Timestamp createDate) {
         this.createDate = createDate;
+    }
+
+    public String getLastBorrowerFirstName() {
+        return lastBorrowerFirstName;
+    }
+
+    public void setLastBorrowerFirstName(String lastBorrowerFirstName) {
+        this.lastBorrowerFirstName = lastBorrowerFirstName;
+    }
+
+    public String getLastBorrowerMiddleName() {
+        return lastBorrowerMiddleName;
+    }
+
+    public void setLastBorrowerMiddleName(String lastBorrowerMiddleName) {
+        this.lastBorrowerMiddleName = lastBorrowerMiddleName;
+    }
+
+    public String getLastBorrowerLastName() {
+        return lastBorrowerLastName;
+    }
+
+    public void setLastBorrowerLastName(String lastBorrowerLastName) {
+        this.lastBorrowerLastName = lastBorrowerLastName;
+    }
+
+    public String getLastBorrowerType() {
+        return lastBorrowerType;
+    }
+
+    public void setLastBorrowerType(String lastBorrowerType) {
+        this.lastBorrowerType = lastBorrowerType;
+    }
+
+    public String getLastBorrowerExpDate() {
+        return lastBorrowerExpDate;
+    }
+
+    public void setLastBorrowerExpDate(String lastBorrowerExpDate) {
+        this.lastBorrowerExpDate = lastBorrowerExpDate;
+    }
+
+    public String getLastBorrowerURL() {
+        return lastBorrowerURL;
+    }
+
+    public void setLastBorrowerURL(String lastBorrowerURL) {
+        this.lastBorrowerURL = lastBorrowerURL;
+    }
+
+    public Timestamp getLastBorrowerItemStatusDate() {
+        return lastBorrowerItemStatusDate;
+    }
+
+    public void setLastBorrowerItemStatusDate(Timestamp lastBorrowerItemStatusDate) {
+        this.lastBorrowerItemStatusDate = lastBorrowerItemStatusDate;
     }
 }

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/OLEDeliverItemSearchController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/OLEDeliverItemSearchController.java
@@ -328,18 +328,18 @@ public class OLEDeliverItemSearchController extends UifControllerBase {
                     if(null != oleCirculationHistory) {
                         Map patronIdMap = new HashMap();
                         patronIdMap.put(OLEConstants.OlePatron.PATRON_ID, oleCirculationHistory.getPatronId());
-                        List<OlePatronDocument> olePatronDocumentList = new ArrayList<OlePatronDocument>();
-                        olePatronDocumentList = (List<OlePatronDocument>) KRADServiceLocator.getBusinessObjectService().findMatching(OlePatronDocument.class, patronIdMap);
-                        singleItemResultDisplayRow.setLastBorrower(olePatronDocumentList.get(0).getBarcode());
+                        OlePatronDocument olePatronDocument = (OlePatronDocument) KRADServiceLocator.getBusinessObjectService().findByPrimaryKey(OlePatronDocument.class, patronIdMap);
+                        singleItemResultDisplayRow.setLastBorrower(olePatronDocument.getBarcode());
                         OlePatronRecordUtil olePatronRecordUtil = new OlePatronRecordUtil();
-                        singleItemResultDisplayRow.setPatronURL(olePatronRecordUtil.patronNameURL(GlobalVariables.getUserSession().getPrincipalId(), olePatronDocumentList.get(0).getOlePatronId()));
-                        singleItemResultDisplayRow.setPatronFirstName(olePatronDocumentList.get(0).getEntity().getNames().get(0).getFirstName());
-                        singleItemResultDisplayRow.setPatronLastName(olePatronDocumentList.get(0).getEntity().getNames().get(0).getLastName());
-                        singleItemResultDisplayRow.setPatronType(olePatronDocumentList.get(0).getOleBorrowerType().getBorrowerTypeName());
-                        singleItemResultDisplayRow.setPatronExpDate(olePatronDocumentList.get(0).getExpirationDate().toString());
+                        singleItemResultDisplayRow.setLastBorrowerURL(olePatronRecordUtil.patronNameURL(GlobalVariables.getUserSession().getPrincipalId(), olePatronDocument.getOlePatronId()));
+                        singleItemResultDisplayRow.setLastBorrowerFirstName(olePatronDocument.getEntity().getNames().get(0).getFirstName());
+                        singleItemResultDisplayRow.setLastBorrowerLastName(olePatronDocument.getEntity().getNames().get(0).getLastName());
+                        singleItemResultDisplayRow.setLastBorrowerMiddleName(olePatronDocument.getEntity().getNames().get(0).getMiddleName());
+                        singleItemResultDisplayRow.setLastBorrowerType(olePatronDocument.getOleBorrowerType().getBorrowerTypeName());
+
+                        singleItemResultDisplayRow.setLastBorrowerExpDate(olePatronDocument.getExpirationDate().toString());
                         singleItemResultDisplayRow.setLastCheckinDate(new Timestamp(oleCirculationHistory.getCheckInDate().getTime()));
-                        itemSearchResultDisplayRow.setLastBorrower(olePatronDocumentList.get(0).getBarcode());
-                        itemSearchResultDisplayRow.setCreateDate(new Timestamp(oleCirculationHistory.getCreateDate().getTime()));
+                        singleItemResultDisplayRow.setLastBorrowerItemStatusDate((new Timestamp(oleCirculationHistory.getCreateDate().getTime())));
                     }
                     if (searchResponse.getSearchResults().size() > 1) {
                         Map itemMap = new HashMap();

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OLEDeliverItemSearchView.xml
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/datadictionary/OLEDeliverItemSearchView.xml
@@ -362,7 +362,7 @@
                         <list>
                             <bean parent="Uif-DataField" p:propertyName="oleSingleItemResultDisplayRow.itemStatusDate"
                                   p:label="Orig. Charge Date"/>
-                            <bean parent="Uif-DataField" p:propertyName="oleSingleItemResultDisplayRow.originalDueDate"
+                            <bean parent="Uif-DataField" p:propertyName="oleSingleItemResultDisplayRow.dueDate"
                                   p:label="Orig. Due Date"/>
                         </list>
                     </property>
@@ -746,19 +746,19 @@
                         <list>
                             <bean parent="Uif-LinkField" p:label="Last Borrower"
                                   p:linkText="@{oleSingleItemResultDisplayRow.lastBorrower}" p:target="_blank"
-                                  p:href="@{oleSingleItemResultDisplayRow.patronURL}"/>
+                                  p:href="@{oleSingleItemResultDisplayRow.lastBorrowerURL}"/>
                             <bean parent="Uif-DataField" p:label="Patron Type"
-                                  p:propertyName="oleSingleItemResultDisplayRow.patronType"/>
+                                  p:propertyName="oleSingleItemResultDisplayRow.lastBorrowerType"/>
                             <bean parent="Uif-DataField" p:label="Patron Expiry Date"
-                                  p:propertyName="oleSingleItemResultDisplayRow.patronExpDate"/>
+                                  p:propertyName="oleSingleItemResultDisplayRow.lastBorrowerExpDate"/>
                             <bean parent="Uif-DataField" p:label="First Name"
-                                  p:propertyName="oleSingleItemResultDisplayRow.patronFirstName"/>
+                                  p:propertyName="oleSingleItemResultDisplayRow.lastBorrowerFirstName"/>
                             <bean parent="Uif-DataField" p:label="Middle Name"
-                                  p:propertyName="oleSingleItemResultDisplayRow.patronMiddleName"/>
+                                  p:propertyName="oleSingleItemResultDisplayRow.lastBorrowerMiddleName"/>
                             <bean parent="Uif-DataField" p:label="Last Name"
-                                  p:propertyName="oleSingleItemResultDisplayRow.patronLastName"/>
-                            <bean parent="Uif-DataField" p:label="Orig.Charge date"
-                                  p:propertyName="oleSingleItemResultDisplayRow.createDate"/>
+                                  p:propertyName="oleSingleItemResultDisplayRow.lastBorrowerLastName"/>
+                            <bean parent="Uif-DataField" p:label="Orig. Charge date"
+                                  p:propertyName="oleSingleItemResultDisplayRow.lastBorrowerItemStatusDate"/>
                             <bean parent="Uif-DataField" p:label="Return Date"
                                   p:propertyName="oleSingleItemResultDisplayRow.lastCheckinDate"/>
                         </list>


### PR DESCRIPTION
OLE-6996 : operators need to be able to view circulation history of an item, including all previous borrowers stored in OLE
