### PR TITLE
OLE-8951 : On saving a Requisition 2 items are created even if only one is ordered

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/select/document/OleRequisitionDocument.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/select/document/OleRequisitionDocument.java
@@ -492,11 +492,11 @@ public class OleRequisitionDocument extends RequisitionDocument {
         //if (requestSourceTypeId == null) {
         setRequestSourceTypeId(singleItem);
         //TODO: Why are we checking this again?
-        //if (requisitionSourceCode.equalsIgnoreCase(OleSelectConstant.REQUISITON_SRC_TYPE_AUTOINGEST)) {
+        if (requisitionSourceCode.equalsIgnoreCase(OleSelectConstant.REQUISITON_SRC_TYPE_AUTOINGEST)) {
         if (singleItem.getCopyList() == null || singleItem.getCopyList().size() == 0) {
             singleItem.setCopyList(getCopyList(singleItem));
         }
-        //}
+        }
         if (singleItem.getBibInfoBean() != null) {
             singleItem.getBibInfoBean().setRequestSource(OleSelectConstant.REQUEST_SRC_TYPE_STAFF);
         }

--- a/ole-app/olefs/src/main/java/org/kuali/ole/select/service/impl/OleReqPOCreateDocumentServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/select/service/impl/OleReqPOCreateDocumentServiceImpl.java
@@ -537,8 +537,8 @@ public class OleReqPOCreateDocumentServiceImpl extends RequisitionCreateDocument
     protected RequisitionItem createRequisitionItem(OleOrderRecord oleOrderRecord, int itemLineNumber, OLEBatchProcessJobDetailsBo job, OleRequisitionDocument requisitionDocument) throws Exception {
         OleRequisitionItem item = new OleRequisitionItem();
         item.setOleOrderRecord(oleOrderRecord);
-        item.setSingleCopyNumber(oleOrderRecord.getOleTxRecord().getSingleCopyNumber());
-        item.setItemPriceSourceId(getItemPriceSourceId(oleOrderRecord.getOleTxRecord()));
+       // item.setSingleCopyNumber(oleOrderRecord.getOleTxRecord().getSingleCopyNumber());
+       // item.setItemPriceSourceId(getItemPriceSourceId(oleOrderRecord.getOleTxRecord()));
         //item.setBibInfoBean(bibInfoBean);
         item.setItemLineNumber(itemLineNumber);
         item.setItemUnitOfMeasureCode(getOlePurapService().getParameter(org.kuali.ole.sys.OLEConstants.UOM));


### PR DESCRIPTION
OLE-8951 : On saving a Requisition 2 items are created even if only one is ordered
