### PR TITLE
OLE-9092  SIP2 Patron Status Response needs to indicate in AF field when borrower denied checkout privileges

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/executors/RequestNoticesExecutor.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/executors/RequestNoticesExecutor.java
@@ -191,6 +191,9 @@ public abstract class RequestNoticesExecutor extends NoticesExecutor {
         String patronBarcode = "";
         if(olePatron!=null){
             patronBarcode = olePatron.getBarcode();
+        }else{
+            patronBarcode = oleDeliverRequestBos.get(0).getOlePatron().getBarcode();
+            patronId = oleDeliverRequestBos.get(0).getOlePatron().getOlePatronId();
         }
         parameterMap.put("patronBarcode", patronBarcode);
         Date dateSent = new Date();

--- a/ole-common/ole-utility/src/main/java/org/kuali/ole/constants/OLESIP2Constants.java
+++ b/ole-common/ole-utility/src/main/java/org/kuali/ole/constants/OLESIP2Constants.java
@@ -132,6 +132,7 @@ public class OLESIP2Constants {
     public static final String YES="YES";
     public static final String ONHOLD="ONHOLD";
     public static final String SCREEN_FAILURE_MSG="Checkout Privileges Denied";
+    public static final String SCREEN_SUCCESS_MSG="Checkout Privileges Permitted";
     public static final String REQUEST_PROCESSED="Requested process completed successfully.";
 
 

--- a/ole-common/ole-utility/src/main/java/org/kuali/ole/constants/OLESIP2Constants.java
+++ b/ole-common/ole-utility/src/main/java/org/kuali/ole/constants/OLESIP2Constants.java
@@ -131,7 +131,6 @@ public class OLESIP2Constants {
     public static final String PATRON_ENABLED="Patron Enabled successfully";
     public static final String YES="YES";
     public static final String ONHOLD="ONHOLD";
-    public static final String SCREEN_FAILURE_MSG="Checkout Privileges Denied";
     public static final String REQUEST_PROCESSED="Requested process completed successfully.";
 
 

--- a/ole-common/ole-utility/src/main/java/org/kuali/ole/constants/OLESIP2Constants.java
+++ b/ole-common/ole-utility/src/main/java/org/kuali/ole/constants/OLESIP2Constants.java
@@ -131,6 +131,7 @@ public class OLESIP2Constants {
     public static final String PATRON_ENABLED="Patron Enabled successfully";
     public static final String YES="YES";
     public static final String ONHOLD="ONHOLD";
+    public static final String SCREEN_FAILURE_MSG="Checkout Privileges Denied";
     public static final String REQUEST_PROCESSED="Requested process completed successfully.";
 
 

--- a/ole-common/ole-utility/src/main/java/org/kuali/ole/response/OLESIP2PatronInformationResponse.java
+++ b/ole-common/ole-utility/src/main/java/org/kuali/ole/response/OLESIP2PatronInformationResponse.java
@@ -159,7 +159,7 @@ public class OLESIP2PatronInformationResponse extends OLESIP2Response {
             builder.append(OLESIP2Constants.SPLIT+
                  OLESIP2Constants.SCREEN_MSG_CODE);
             if(oleLookupUser.isValidPatron()==true){
-                builder.append(oleLookupUser.getMessage());
+                builder.append(OLESIP2Constants.SCREEN_SUCCESS_MSG);
             }else{
                 builder.append(OLESIP2Constants.SCREEN_FAILURE_MSG);
             }

--- a/ole-common/ole-utility/src/main/java/org/kuali/ole/response/OLESIP2PatronInformationResponse.java
+++ b/ole-common/ole-utility/src/main/java/org/kuali/ole/response/OLESIP2PatronInformationResponse.java
@@ -158,7 +158,11 @@ public class OLESIP2PatronInformationResponse extends OLESIP2Response {
         if (StringUtils.isNotBlank(oleLookupUser.getMessage())) {
             builder.append(OLESIP2Constants.SPLIT+
                  OLESIP2Constants.SCREEN_MSG_CODE);
-            builder.append(oleLookupUser.getMessage());
+            if(oleLookupUser.isValidPatron()==true){
+                builder.append(oleLookupUser.getMessage());
+            }else{
+                builder.append(OLESIP2Constants.SCREEN_FAILURE_MSG);
+            }
         }
 
         if (StringUtils.isNotBlank(sip2PatronInformationRequestParser.getSequenceNum())) {

--- a/ole-common/ole-utility/src/main/java/org/kuali/ole/response/OLESIP2PatronInformationResponse.java
+++ b/ole-common/ole-utility/src/main/java/org/kuali/ole/response/OLESIP2PatronInformationResponse.java
@@ -158,11 +158,7 @@ public class OLESIP2PatronInformationResponse extends OLESIP2Response {
         if (StringUtils.isNotBlank(oleLookupUser.getMessage())) {
             builder.append(OLESIP2Constants.SPLIT+
                  OLESIP2Constants.SCREEN_MSG_CODE);
-            if(oleLookupUser.isValidPatron()==true){
-                builder.append(oleLookupUser.getMessage());
-            }else{
-                builder.append(OLESIP2Constants.SCREEN_FAILURE_MSG);
-            }
+            builder.append(oleLookupUser.getMessage());
         }
 
         if (StringUtils.isNotBlank(sip2PatronInformationRequestParser.getSequenceNum())) {


### PR DESCRIPTION
OLE-9092   SIP2 Patron Status Response needs to indicate in AF field when borrower denied checkout privileges