### PR TITLE
OLE-9019 : Error messages written to patron notices when notice formatter cannot deal with data

### DIFF
--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/notice/noticeFormatters/request-notice.ftl
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/notice/noticeFormatters/request-notice.ftl
@@ -80,7 +80,9 @@
 
 
 <#list oleNoticeBos as oleNoticeBo>
-    <@itemInfo.item oleNoticeBo=oleNoticeBo oleNoticeContentConfigurationBo=oleNoticeContentConfigurationBo></@itemInfo.item>
+    <#if oleNoticeContentConfigurationBo??>
+        <@itemInfo.item oleNoticeBo=oleNoticeBo oleNoticeContentConfigurationBo=oleNoticeContentConfigurationBo></@itemInfo.item>
+    </#if>
 <#if oleNoticeBo_has_next>
 ********************************************************************
 </#if>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/service/notice.ftl
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/service/notice.ftl
@@ -113,7 +113,7 @@
 
 <#list oleNoticeBos as oleNoticeBo>
     <#if oleNoticeContentConfigurationBo??>
-        <#if oleNoticeBo.noticeTitle == "Lost">
+        <#if oleNoticeBo.noticeType == "Lost">
             <@bill.bill oleNoticeBo=oleNoticeBo oleNoticeContentConfigurationBo=oleNoticeContentConfigurationBo></@bill.bill>
         </#if>
         <br/>


### PR DESCRIPTION
OLE-9019 : Error messages written to patron notices when notice formatter cannot deal with data