### PR TITLE
OLE-8923       generateHoldCourtesyNoticeJob sends email notices even though ntc_snd_typ set to "mail"

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/service/impl/OleNoticeServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/service/impl/OleNoticeServiceImpl.java
@@ -67,6 +67,7 @@ public class OleNoticeServiceImpl implements OleNoticeService {
             oleDeliverNotice.setNoticeContentConfigName(oleDeliverRequestBo.getRequestExpirationNoticeContentConfigName());
         }
         else if (noticeType.equalsIgnoreCase(OLEConstants.ONHOLD_EXPIRATION_NOTICE)){
+            oleDeliverNotice.setNoticeSendType(getNoticeUtil().getParameter(OLEConstants.HOLD_COUR_NOT_TYP));
             oleDeliverNotice.setNoticeContentConfigName(oleDeliverRequestBo.getOnHoldExpirationNoticeContentConfigName());
         }
         else if (noticeType.equalsIgnoreCase(OLEConstants.ONHOLD_NOTICE)){


### PR DESCRIPTION
OLE-8923       generateHoldCourtesyNoticeJob sends email notices even though ntc_snd_typ set to "mail"