### PR TITLE
OLE-9137, OLE-9143 & OLE-9146

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/controller/OleNoticeContentConfigurationMaintenanceController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/controller/OleNoticeContentConfigurationMaintenanceController.java
@@ -5,6 +5,7 @@ import org.kuali.ole.deliver.notice.bo.OleNoticeContentConfigurationBo;
 import org.kuali.ole.deliver.notice.bo.OleNoticeFieldLabelMapping;
 import org.kuali.rice.krad.maintenance.MaintenanceDocument;
 import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.KRADConstants;
 import org.kuali.rice.krad.web.controller.MaintenanceDocumentController;
 import org.kuali.rice.krad.web.form.DocumentFormBase;
 import org.kuali.rice.krad.web.form.MaintenanceDocumentForm;
@@ -63,6 +64,18 @@ public class OleNoticeContentConfigurationMaintenanceController extends Maintena
         return super.refresh(form,result,request,response);
     }
 
+    @Override
+    @RequestMapping(params = "methodToCall=maintenanceEdit")
+    public ModelAndView maintenanceEdit(@ModelAttribute("KualiForm") MaintenanceDocumentForm form, BindingResult result,
+                                        HttpServletRequest request, HttpServletResponse response) throws Exception {
 
+        MaintenanceDocumentForm maintenanceForm = form;
+        setupMaintenance(form, request, KRADConstants.MAINTENANCE_EDIT_ACTION);
+        MaintenanceDocument document =  maintenanceForm.getDocument();
+        OleNoticeContentConfigurationBo oleNoticeContentConfigurationBo = (OleNoticeContentConfigurationBo) document.getNewMaintainableObject().getDataObject();
+        String noticeType = oleNoticeContentConfigurationBo.getNoticeType();
+        GlobalVariables.getUserSession().addObject("noticeType",noticeType);
+        return getUIFModelAndView(form);
+    }
 
 }

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/executors/HoldExpirationNoticesExecutor.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/executors/HoldExpirationNoticesExecutor.java
@@ -49,7 +49,7 @@ public class HoldExpirationNoticesExecutor extends RequestNoticesExecutor {
     public void setOleNoticeContentConfigurationBo() {
         List<OleNoticeContentConfigurationBo> oleNoticeContentConfigurationBoList = null;
         Map<String,String> noticeConfigurationMap = new HashMap<String,String>();
-        noticeConfigurationMap.put("noticeType",OLEConstants.NOTICE_HOLD_COURTESY);
+        noticeConfigurationMap.put("noticeType",OLEConstants.ONHOLD_EXPIRATION_NOTICE);
         noticeConfigurationMap.put("noticeName", noticeContentConfigName);
         oleNoticeContentConfigurationBoList= (List<OleNoticeContentConfigurationBo>)getBusinessObjectService().findMatching(OleNoticeContentConfigurationBo.class,noticeConfigurationMap);
         if(CollectionUtils.isNotEmpty(oleNoticeContentConfigurationBoList)){
@@ -82,6 +82,6 @@ public class HoldExpirationNoticesExecutor extends RequestNoticesExecutor {
 
     @Override
     public String getType() {
-        return OLEConstants.NOTICE_HOLD_COURTESY;
+        return OLEConstants.ONHOLD_EXPIRATION_NOTICE;
     }
 }

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/service/impl/OleNoticeServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/service/impl/OleNoticeServiceImpl.java
@@ -74,7 +74,7 @@ public class OleNoticeServiceImpl implements OleNoticeService {
             oleDeliverNotice.setNoticeContentConfigName(oleDeliverRequestBo.getOnHoldNoticeContentConfigName());
         }
         else if (noticeType.equalsIgnoreCase(OLEConstants.ONHOLD_COURTESY_NOTICE)){
-            oleDeliverNotice.setNoticeContentConfigName(oleDeliverRequestBo.getOnHoldNoticeContentConfigName());
+            oleDeliverNotice.setNoticeContentConfigName(oleDeliverRequestBo.getOnHoldCourtesyNoticeContentConfigName());
         }
         oleDeliverNotice.setItemBarcode(oleDeliverRequestBo.getItemId());
         oleDeliverNotice.setNoticeType(noticeType);

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeItemFieldLabelMappingKeyValuesFinder.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeItemFieldLabelMappingKeyValuesFinder.java
@@ -33,7 +33,7 @@ public class OleNoticeItemFieldLabelMappingKeyValuesFinder extends KeyValuesBase
         keyValues.add(new ConcreteKeyValue(OLEConstants.NOTICE_CALL_NUMBER,OLEConstants.NOTICE_CALL_NUMBER));
         keyValues.add(new ConcreteKeyValue(OLEConstants.NOTICE_CALL_NUMBER_PREFIX,OLEConstants.NOTICE_CALL_NUMBER_PREFIX));
         keyValues.add(new ConcreteKeyValue(OLEConstants.NOTICE_ITEM_BARCODE,OLEConstants.NOTICE_ITEM_BARCODE));
-        if(StringUtils.isNotEmpty(noticeType) && (noticeType.equals(OLEConstants.RECALL_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_NOTICE) || noticeType.equals(OLEConstants.NOTICE_HOLD_COURTESY)  || noticeType.equals(OLEConstants.REQUEST_EXPIRATION_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_COURTESY_NOTICE))) {
+        if(StringUtils.isNotEmpty(noticeType) && (noticeType.equals(OLEConstants.RECALL_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_EXPIRATION_NOTICE) || noticeType.equals(OLEConstants.REQUEST_EXPIRATION_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_COURTESY_NOTICE))) {
             keyValues.add(new ConcreteKeyValue(OLEConstants.CIRCULATION_LOCATION_LIBRARY_NAME,OLEConstants.CIRCULATION_LOCATION_LIBRARY_NAME));
             keyValues.add(new ConcreteKeyValue(OLEConstants.CIRCULATION_REPLY_TO_EMAIL,OLEConstants.CIRCULATION_REPLY_TO_EMAIL));
             keyValues.add(new ConcreteKeyValue(OLEConstants.LIBRARY_SHELVING_LOCATION,OLEConstants.LIBRARY_SHELVING_LOCATION));
@@ -43,7 +43,7 @@ public class OleNoticeItemFieldLabelMappingKeyValuesFinder extends KeyValuesBase
         keyValues.add(new ConcreteKeyValue(OLEConstants.ORIGINAL_DUE_DATE,OLEConstants.ORIGINAL_DUE_DATE));
         keyValues.add(new ConcreteKeyValue(OLEConstants.NEW_DUE_DATE,OLEConstants.NEW_DUE_DATE));
         }
-        if(StringUtils.isNotEmpty(noticeType) && (noticeType.equals(OLEConstants.ONHOLD_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_COURTESY_NOTICE))){
+        if(StringUtils.isNotEmpty(noticeType) && (noticeType.equals(OLEConstants.ONHOLD_NOTICE) || noticeType.equals(OLEConstants.ONHOLD_EXPIRATION_NOTICE))){
             keyValues.add(new ConcreteKeyValue(OLEConstants.ITEM_WILL_BE_HELD_UNTIL,OLEConstants.ITEM_WILL_BE_HELD_UNTIL));
         }
 

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeTypeKeyValuesFinder.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeTypeKeyValuesFinder.java
@@ -19,7 +19,7 @@ public class OleNoticeTypeKeyValuesFinder  extends KeyValuesBase {
         keyValues.add(new ConcreteKeyValue("",""));
         keyValues.add(new ConcreteKeyValue(OLEConstants.RECALL_NOTICE,"Recall Notice"));
         keyValues.add(new ConcreteKeyValue(OLEConstants.ONHOLD_NOTICE,"OnHold Notice"));
-        keyValues.add(new ConcreteKeyValue(OLEConstants.NOTICE_HOLD_COURTESY,"Hold Expiration Notice"));
+        keyValues.add(new ConcreteKeyValue(OLEConstants.ONHOLD_EXPIRATION_NOTICE,"OnHold Expiration Notice"));
         keyValues.add(new ConcreteKeyValue(OLEConstants.REQUEST_EXPIRATION_NOTICE,"Request Expiration Notice"));
         keyValues.add(new ConcreteKeyValue(OLEConstants.ONHOLD_COURTESY_NOTICE,"OnHold Courtesy Notice"));
         keyValues.add(new ConcreteKeyValue(OLEConstants.COURTESY_NOTICE,"Courtesy Notice"));

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/OleDeliverRequestDocumentHelperServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/OleDeliverRequestDocumentHelperServiceImpl.java
@@ -2177,7 +2177,7 @@ public class OleDeliverRequestDocumentHelperServiceImpl {
         oleNoticeBo.setPatronAddress(getOlePatronHelperService().getPatronPreferredAddress(entityTypeContactInfoBo) != null ? getOlePatronHelperService().getPatronPreferredAddress(entityTypeContactInfoBo) : "");
         oleNoticeBo.setPatronEmailAddress(getOlePatronHelperService().getPatronHomeEmailId(entityTypeContactInfoBo) != null ? getOlePatronHelperService().getPatronHomeEmailId(entityTypeContactInfoBo) : "");
         oleNoticeBo.setPatronPhoneNumber(getOlePatronHelperService().getPatronHomePhoneNumber(entityTypeContactInfoBo) != null ? getOlePatronHelperService().getPatronHomePhoneNumber(entityTypeContactInfoBo) : "");
-        oleNoticeBo.setNoticeName(OLEConstants.NOTICE_HOLD_COURTESY);
+        oleNoticeBo.setNoticeName(OLEConstants.ONHOLD_EXPIRATION_NOTICE);
         oleNoticeBo.setNoticeSpecificContent(getLoanProcessor().getParameter(OLEConstants.OleDeliverRequest.EXP_HOLD_NOTICE_CONTENT));
         oleNoticeBo.setTitle(item.getHolding().getBib().getTitle());
         oleNoticeBo.setAuthor(item.getHolding().getBib().getAuthor());

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/notice/noticeFormatters/request-itemInfo.ftl
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/notice/noticeFormatters/request-itemInfo.ftl
@@ -117,7 +117,7 @@
                 <#if oleNoticeBo.originalDueDate ??>
                     <TD>${(oleNoticeBo.originalDueDate)?date}</TD>
                 <#else>
-                    <TD</TD>
+                    <TD></TD>
                 </#if>
 
             </TR>


### PR DESCRIPTION
OLE-9137 Location no longer in drop down box for author/title information on Notice Content Configuration Screen
OLE-9143 New Notice type Hold Expiration Notice is saved as HoldCourtesy Notice type
OLE-9146 Recall Notice original due date displays html tags when original due date is null