### PR TITLE
OLE-9095   NCIP AcceptItem does not always set "staff only" flags   &  OLE-9160   SRU call to add temporary item type changes staff only flag from Y to N & OLE-9161 Recalling an item changes the staff only flag from Y to N 	

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/OleDeliverRequestDocumentHelperServiceImpl.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/OleDeliverRequestDocumentHelperServiceImpl.java
@@ -4198,6 +4198,7 @@ public class OleDeliverRequestDocumentHelperServiceImpl {
             item.setCategory(OLEConstants.WORK_CATEGORY);
             item.setType(DocType.ITEM.getCode());
             item.setFormat(OLEConstants.OLEML_FORMAT);
+            item.setStaffOnly(oleItem.isStaffOnlyFlag());
             getDocstoreClientLocator().getDocstoreClient().updateItem(item);
         } catch (Exception e) {
             LOG.error(OLEConstants.ITM_STS_TO_DOC_FAIL + e, e);

--- a/ole-common/ole-docstore-common/src/main/java/org/kuali/ole/docstore/common/document/Item.java
+++ b/ole-common/ole-docstore-common/src/main/java/org/kuali/ole/docstore/common/document/Item.java
@@ -993,11 +993,15 @@ public class Item
         if (StringUtils.isNotBlank(incomingItemContent.getResourceIdentifier())) {
             existingItemContent.setResourceIdentifier(incomingItemContent.getResourceIdentifier());
         }
-        if (incomingItemContent.isStaffOnlyFlag() != existingItemContent.isStaffOnlyFlag()) {
+        if(itemIncoming.getContent() != null &&  itemIncoming.getContent().contains("<staffOnlyFlag>")){
+            existingItemContent.setStaffOnlyFlag(incomingItemContent.isStaffOnlyFlag());
+            this.setStaffOnly(incomingItemContent.isStaffOnlyFlag());
+        }
+        /*if (incomingItemContent.isStaffOnlyFlag() != existingItemContent.isStaffOnlyFlag()) {
             existingItemContent.setStaffOnlyFlag(incomingItemContent.isStaffOnlyFlag());
             this.setStaffOnly(incomingItemContent.isStaffOnlyFlag());
 
-        }
+        }*/
         this.setContent(itemOlemlRecordProcessor.toXML(existingItemContent));
     }
 


### PR DESCRIPTION
OLE-9095   NCIP AcceptItem does not always set "staff only" flags   &  OLE-9160   SRU call to add temporary item type changes staff only flag from Y to N & OLE-9161 Recalling an item changes the staff only flag from Y to N 	