### PR TITLE
OLE-9183   Solr-client: The display of the number of items indexed is wrong

### DIFF
--- a/solr-client/src/main/java/org/kuali/ole/indexer/HoldingIndexer.java
+++ b/solr-client/src/main/java/org/kuali/ole/indexer/HoldingIndexer.java
@@ -79,8 +79,8 @@ public class HoldingIndexer extends OleDsNgIndexer {
                     itemUUIds.add(itemIdentifierWithPrefix);
                     processed++;
                 }
-                recordCountAndSolrDocumentMap.setNumberOfItemsFetched(itemRecords.size());
-                recordCountAndSolrDocumentMap.setNumberOfItemsProcessed(processed);
+                recordCountAndSolrDocumentMap.setNumberOfItemsFetched(recordCountAndSolrDocumentMap.getNumberOfItemsFetched() + itemRecords.size());
+                recordCountAndSolrDocumentMap.setNumberOfItemsProcessed(recordCountAndSolrDocumentMap.getNumberOfItemsProcessed() + processed);
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
OLE-9183   Solr-client: The display of the number of items indexed is wrong