### PR TITLE
OLE-9190 : Leaving due time blank when performing a renewal override does not use default end time

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/CircController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/CircController.java
@@ -520,6 +520,9 @@ public class CircController extends CheckoutValidationController {
                         if(StringUtils.isBlank(dueDateAndTime[1])) {
                             dueDateAndTime[1] =ParameterValueResolver.getInstance().getParameter(OLEConstants
                                     .APPL_ID_OLE, OLEConstants.DLVR_NMSPC, OLEConstants.DLVR_CMPNT, OLEConstants.DEFAULT_TIME_FOR_DUE_DATE);
+                            if(StringUtils.isBlank(dueDateAndTime[1])){
+                                dueDateAndTime[1] = new CircUtilController().getDefaultClosingTime(loanDocument,getDateFromString(dateString));
+                            }
                         }
                         newDueDate = getCheckoutUIController(circForm.getFormKey()).processDateAndTimeForAlterDueDate(getDateFromString(dateString), dueDateAndTime[1]);
                     }
@@ -577,6 +580,9 @@ public class CircController extends CheckoutValidationController {
                 if(StringUtils.isBlank(dueDateAndTime[1])) {
                     dueDateAndTime[1] = ParameterValueResolver.getInstance().getParameter(OLEConstants
                             .APPL_ID_OLE, OLEConstants.DLVR_NMSPC, OLEConstants.DLVR_CMPNT, OLEConstants.DEFAULT_TIME_FOR_DUE_DATE);
+                    if(StringUtils.isBlank(dueDateAndTime[1])){
+                        dueDateAndTime[1] = new CircUtilController().getDefaultClosingTime(oleLoanDocument, getDateFromString(dateString));
+                    }
                 }
                 newDueDate = getCheckoutUIController(circForm.getFormKey()).processDateAndTimeForAlterDueDate(getDateFromString(dateString), dueDateAndTime[1]);
             }

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/checkout/CheckoutUIController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/checkout/CheckoutUIController.java
@@ -122,7 +122,12 @@ public class CheckoutUIController extends CheckoutBaseController {
         } else if (fmt.format(customDueDateMap).compareTo(fmt.format(new Date())) == 0) {
             timestamp = new Timestamp(new Date().getTime());
         } else {
-            timestamp = Timestamp.valueOf(new SimpleDateFormat(OLEConstants.CHECK_IN_DATE_TIME_FORMAT).format(customDueDateMap).concat(" ").concat(new SimpleDateFormat("HH:mm:ss").format(new Date())));
+            String closingTime = getDefaultClosingTime(oleLoanDocument,customDueDateMap);
+            if(StringUtils.isNotBlank(closingTime)) {
+                timestamp = Timestamp.valueOf(new SimpleDateFormat(OLEConstants.CHECK_IN_DATE_TIME_FORMAT).format(customDueDateMap).concat(" ").concat(closingTime).concat(":00"));
+            }else{
+                timestamp = Timestamp.valueOf(new SimpleDateFormat(OLEConstants.CHECK_IN_DATE_TIME_FORMAT).format(customDueDateMap).concat(" ").concat(new SimpleDateFormat("HH:mm:ss").format(new Date())));
+            }
         }
         oleLoanDocument.setLoanDueDate(timestamp);
         oleLoanDocument.setCirculationPolicyId(OLEConstants.NO_CIRC_POLICY_FOUND);

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/checkout/CircUtilController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/checkout/CircUtilController.java
@@ -7,6 +7,8 @@ import org.kuali.ole.OLEConstants;
 import org.kuali.ole.deliver.OleLoanDocumentsFromSolrBuilder;
 import org.kuali.ole.deliver.PatronBillGenerator;
 import org.kuali.ole.deliver.bo.*;
+import org.kuali.ole.deliver.calendar.bo.OleCalendar;
+import org.kuali.ole.deliver.calendar.bo.OleCalendarWeek;
 import org.kuali.ole.deliver.controller.drools.RuleExecutor;
 import org.kuali.ole.deliver.controller.notices.*;
 import org.kuali.ole.deliver.notice.bo.OleNoticeContentConfigurationBo;
@@ -775,6 +777,34 @@ public class CircUtilController extends RuleExecutor {
 
     public void setParameterValueResolver(ParameterValueResolver parameterValueResolver) {
         this.parameterValueResolver = parameterValueResolver;
+    }
+
+    public String getDefaultClosingTime(OleLoanDocument oleLoanDocument,Date dueDate){
+        String closingTime = null;
+
+        OleCirculationDesk circulationDesk = (oleLoanDocument.getCirculationLocationId() != null ? new CircDeskLocationResolver().getOleCirculationDesk(oleLoanDocument.getCirculationLocationId()):null);
+        if(circulationDesk != null){
+            LoanDateTimeUtil loanDateTimeUtil =new LoanDateTimeUtil();
+            OleCalendar oleCalendar = loanDateTimeUtil.getActiveCalendar(dueDate,circulationDesk.getCalendarGroupId());
+            if(oleCalendar != null){
+                int day = dueDate.getDay();
+                List<OleCalendarWeek> oleCalendarWeekList = oleCalendar.getOleCalendarWeekList();
+                if(CollectionUtils.isNotEmpty(oleCalendarWeekList)){
+                    for(Iterator<OleCalendarWeek> iterator = oleCalendarWeekList.iterator(); iterator.hasNext();){
+                        OleCalendarWeek oleCalendarWeek =  iterator.next();
+                        if(oleCalendarWeek.getStartDay().equalsIgnoreCase(String.valueOf(day))){
+                            closingTime = oleCalendarWeek.getCloseTime();
+                            break;
+                        }else if ((day >= Integer.valueOf(oleCalendarWeek.getStartDay())) && day <= Integer.valueOf(oleCalendarWeek.getEndDay())){
+                            closingTime = oleCalendarWeek.getCloseTime();
+                            break;
+                        }
+                    }
+                }
+            }
+
+        }
+        return closingTime;
     }
 
 }

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/renew/RenewController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/renew/RenewController.java
@@ -332,29 +332,7 @@ public class RenewController extends CircUtilController {
             if(dueTime!=null){
                 oleLoanDocument.setRenewalDateTime(dueTime);
             }else{
-                OleCirculationDesk circulationDesk = (oleLoanDocument.getCirculationLocationId() != null ? new CircDeskLocationResolver().getOleCirculationDesk(oleLoanDocument.getCirculationLocationId()):null);
-                if(circulationDesk != null){
-                    LoanDateTimeUtil loanDateTimeUtil =new LoanDateTimeUtil();
-                    OleCalendar oleCalendar = loanDateTimeUtil.getActiveCalendar(oleLoanDocument.getLoanDueDate(),circulationDesk.getCalendarGroupId());
-                    if(oleCalendar != null){
-                        int day = oleLoanDocument.getLoanDueDate().getDay();
-                        List<OleCalendarWeek> oleCalendarWeekList = oleCalendar.getOleCalendarWeekList();
-                        if(CollectionUtils.isNotEmpty(oleCalendarWeekList)){
-                            for(Iterator<OleCalendarWeek> iterator = oleCalendarWeekList.iterator(); iterator.hasNext();){
-                                OleCalendarWeek oleCalendarWeek =  iterator.next();
-                                System.out.println("Close Time: "+oleCalendarWeek.getCloseTime());
-                                if(oleCalendarWeek.getStartDay().equalsIgnoreCase(String.valueOf(day))){
-                                    oleLoanDocument.setRenewalDateTime(oleCalendarWeek.getCloseTime());
-                                    break;
-                                }else if ((day >= Integer.valueOf(oleCalendarWeek.getStartDay())) && day <= Integer.valueOf(oleCalendarWeek.getEndDay())){
-                                    oleLoanDocument.setRenewalDateTime(oleCalendarWeek.getCloseTime());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                }
+                oleLoanDocument.setRenewalDateTime(getDefaultClosingTime(oleLoanDocument,oleLoanDocument.getLoanDueDate()));
             }
         }
     }


### PR DESCRIPTION
OLE-9190 : Leaving due time blank when performing a renewal override does not use default end time