### PR TITLE
OLE-9254 & OLE-9296

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/executors/LoanNoticesExecutor.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/executors/LoanNoticesExecutor.java
@@ -49,7 +49,8 @@ public abstract class LoanNoticesExecutor extends NoticesExecutor {
         String mailContent = generateMailContent(loanDocuments);
         if(StringUtils.isNotBlank(mailContent) && !mailContent.contains("FreeMarker template error")) {
             if(!(this instanceof ClaimsReturnedNoticesExecutor)){
-                preProcess(loanDocuments);
+               preProcess(loanDocuments);
+               mailContent = generateMailContent(loanDocuments);
             }
             //4. Generate notices
             List<OLEDeliverNotice> oleDeliverNotices = buildNoticesForDeletion();

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeItemFieldLabelMappingKeyValuesFinder.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeItemFieldLabelMappingKeyValuesFinder.java
@@ -59,7 +59,6 @@ public class OleNoticeItemFieldLabelMappingKeyValuesFinder extends KeyValuesBase
             keyValues.add(new ConcreteKeyValue(OLEConstants.MISSING_ITEM_NOTE,OLEConstants.MISSING_ITEM_NOTE));
         }
         if(StringUtils.isNotEmpty(noticeType) && noticeType.equals(OLEConstants.NOTICE_LOST)){
-            keyValues.add(new ConcreteKeyValue(OLEConstants.LIBRARY_SHELVING_LOCATION,OLEConstants.LIBRARY_SHELVING_LOCATION));
             keyValues.add(new ConcreteKeyValue("Bill Number","Bill Number"));
             keyValues.add(new ConcreteKeyValue(OLEConstants.FEE_TYPE,OLEConstants.FEE_TYPE));
             keyValues.add(new ConcreteKeyValue(OLEConstants.FEE_AMT,OLEConstants.FEE_AMT));

--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/NoticeMailContentFormatter.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/service/NoticeMailContentFormatter.java
@@ -268,7 +268,6 @@ public abstract class NoticeMailContentFormatter {
 
         fileNames.add("notice.ftl");
         fileNames.add("itemInfo.ftl");
-        fileNames.add("replacement-bill.ftl");
 
         return fileNames;
     }

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/notice/noticeFormatters/request-itemInfo.ftl
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/notice/noticeFormatters/request-itemInfo.ftl
@@ -104,9 +104,9 @@
                         </#if>
                     </TR>
                     <#break>
-                <#case "Library Shelving location">
+                <#case "Library shelving location">
                     <TR>
-                        <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Library Shelving location")} :</TD>
+                        <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Library shelving location")} :</TD>
                         <#if oleNoticeBo.itemShelvingLocation ??>
                             <TD>${oleNoticeBo.itemShelvingLocation}</TD>
                         <#else>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/service/itemInfo.ftl
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/service/itemInfo.ftl
@@ -95,9 +95,9 @@
                       </#if>
                   </TR>
                   <#break>
-              <#case "Library location">
+              <#case "Library Location">
                   <TR>
-                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Library location")} :</TD>
+                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Library Location")} :</TD>
                       <#if oleNoticeBo.itemLibrary ??>
                           <TD>${oleNoticeBo.itemLibrary}</TD>
                       <#else>
@@ -105,9 +105,9 @@
                       </#if>
                   </TR>
                   <#break>
-              <#case "Library Shelving location">
+              <#case "Library shelving location">
                   <TR>
-                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Library Shelving location")} :</TD>
+                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Library shelving location")} :</TD>
                       <#if oleNoticeBo.itemShelvingLocation ??>
                           <TD>${oleNoticeBo.itemShelvingLocation}</TD>
                       <#else>
@@ -144,6 +144,7 @@
                           <TD</TD>
                       </#if>
                   </TR>
+                  <#break>
               <#case "Item Type">
                   <TR>
                       <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Item Type")} :</TD>
@@ -152,6 +153,39 @@
                       <#else>
                           <TD</TD>
                       </#if>
+                  </TR>
+                  <#break>
+              <#case "Bill Number">
+                  <TR>
+                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Bill Number")} :</TD>
+                      <#if oleNoticeBo.billNumber ??  >
+                          <TD>${oleNoticeBo.billNumber}</TD>
+                      <#else>
+                          <TD></TD>
+                      </#if>
+
+                  </TR>
+                  <#break>
+              <#case "Fee Type">
+                  <TR>
+                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Fee Type")} :</TD>
+                      <#if oleNoticeBo.feeType ??  >
+                          <TD>${oleNoticeBo.feeType}</TD>
+                      <#else>
+                          <TD></TD>
+                      </#if>
+
+                  </TR>
+                  <#break>
+              <#case "Fee Amount">
+                  <TR>
+                      <TD>${oleNoticeContentConfigurationBo.getFieldLabel("Fee Amount")} :</TD>
+                      <#if oleNoticeBo.feeAmount ??  >
+                          <TD>${oleNoticeBo.feeAmount}</TD>
+                      <#else>
+                          <TD></TD>
+                      </#if>
+
                   </TR>
                   <#break>
           </#switch>

--- a/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/service/notice.ftl
+++ b/ole-app/olefs/src/main/resources/org/kuali/ole/deliver/service/notice.ftl
@@ -1,5 +1,4 @@
 <#import "itemInfo.ftl" as itemInfo >
-<#import "replacement-bill.ftl" as bill>
 
 <HTML>
 <#if oleNoticeBo.noticeTitle ??  >
@@ -113,10 +112,6 @@
 
 <#list oleNoticeBos as oleNoticeBo>
     <#if oleNoticeContentConfigurationBo??>
-        <#if oleNoticeBo.noticeType == "Lost">
-            <@bill.bill oleNoticeBo=oleNoticeBo oleNoticeContentConfigurationBo=oleNoticeContentConfigurationBo></@bill.bill>
-        </#if>
-        <br/>
         <@itemInfo.item oleNoticeBo=oleNoticeBo oleNoticeContentConfigurationBo=oleNoticeContentConfigurationBo></@itemInfo.item>
     </#if>
 <#if oleNoticeBo_has_next>


### PR DESCRIPTION
OLE-9254 notices ignoring field label mapping in notice content configuration  & 
OLE-9296   Lost Notices do not have amount on notice and format incorrectly