### PR TITLE
OLE-8900   New batch - allow use of holdings id and item ids as match points for holdings / eholdings / item overlays

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/spring/batch/processor/BatchBibFileProcessor.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/spring/batch/processor/BatchBibFileProcessor.java
@@ -587,7 +587,9 @@ public class BatchBibFileProcessor extends BatchFileProcessor {
                 }
                 matchpointForDataMapping.put(key, valueArray);
             }
-            dataMapping.put(OleNGConstants.MATCHPOINT_FOR_DATAMAPPING,matchpointForDataMapping);
+            if(matchpointForDataMapping.length() > 0) {
+                dataMapping.put(OleNGConstants.MATCHPOINT_FOR_DATAMAPPING, matchpointForDataMapping);
+            }
         } catch (JSONException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
OLE-8900   New batch - allow use of holdings id and item ids as match points for holdings / eholdings / item overlays