### PR TITLE
OLE-9328   Return screen backdate/time automatic timeout resets to system time even when staff are actively scanning items

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/checkin/CheckinItemController.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/controller/checkin/CheckinItemController.java
@@ -86,9 +86,9 @@ public class CheckinItemController extends OLEUifControllerBase {
             }
         }
         setPrintFormatAndHoldSlipQueue(checkinForm);
-        String maxTimeoutCount = ParameterValueResolver.getInstance().getParameter(OLEConstants
+        /*String maxTimeoutCount = ParameterValueResolver.getInstance().getParameter(OLEConstants
                 .APPL_ID, OLEConstants.DLVR_NMSPC, OLEConstants.DLVR_CMPNT, OLEConstants.MAX_TIME_CHECK_IN);
-        checkinForm.setMaxSessionTime(maxTimeoutCount);
+        checkinForm.setMaxSessionTime(maxTimeoutCount);*/
         return super.start(checkinForm, result, request, response);
     }
 


### PR DESCRIPTION
OLE-9328   Return screen backdate/time automatic timeout resets to system time even when staff are actively scanning items