### PR TITLE
OLE-9342 : Due date incorrectly assigned to calendar exception closed date

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/util/LoanDateTimeUtil.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/util/LoanDateTimeUtil.java
@@ -86,6 +86,12 @@ public class LoanDateTimeUtil extends ExceptionDateLoanDateTimeUtil {
                 loanDueDate = handleNonWorkingHoursWorkflow(loanDueDate, oleCalendarExceptionPeriodWeekList);
             }
         }
+        if(isDateAnExceptionDate(getActiveCalendar(), loanDueDate) != null) {
+            loanDueDate = calculateDueDate(loanDueDate);
+        }
+        else if(doesDateFallInExceptionPeriod(getActiveCalendar(), loanDueDate) != null){
+            loanDueDate = calculateDueDate(loanDueDate);
+        }
         return loanDueDate;
     }
 


### PR DESCRIPTION
OLE-9342 : Due date incorrectly assigned to calendar exception closed date