### PR TITLE
OLE-9365 : The checkout receipt notice type is missing from the notice type drop down

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeTypeKeyValuesFinder.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/notice/valuesFinder/OleNoticeTypeKeyValuesFinder.java
@@ -26,6 +26,7 @@ public class OleNoticeTypeKeyValuesFinder  extends KeyValuesBase {
         keyValues.add(new ConcreteKeyValue(OLEConstants.OVERDUE_NOTICE,"Overdue Notice"));
         keyValues.add(new ConcreteKeyValue(OLEConstants.MISSING_PIECE_NOTICE,"Missing Piece Notice"));
         keyValues.add(new ConcreteKeyValue(OLEConstants.NOTICE_LOST,"Lost Notice"));
+        keyValues.add(new ConcreteKeyValue(OLEConstants.CHECKOUT_RECEIPT_NOTICE,OLEConstants.CHECKOUT_RECEIPT_NOTICE));
         keyValues.add(new ConcreteKeyValue(OLEConstants.CANCELLATION_NOTICE,OLEConstants.CANCELLATION_NOTICE));
         keyValues.add(new ConcreteKeyValue(OLEConstants.CLAIMS_RETURNED_NOTICE,OLEConstants.CLAIMS_RETURNED_NOTICE));
         keyValues.add(new ConcreteKeyValue(OLEConstants.CLAIMS_RETURNED_FOUND_NO_FEES_NOTICE,OLEConstants.CLAIMS_RETURNED_FOUND_NO_FEES_NOTICE));


### PR DESCRIPTION
OLE-9365 : The checkout receipt notice type is missing from the notice type drop down