### PR TITLE
OLE-9409 :  Updating request expiration date fails to update the notice send date for request expiration notices

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/rule/OleDeliverRequestDocumentRule.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/rule/OleDeliverRequestDocumentRule.java
@@ -207,6 +207,15 @@ public class OleDeliverRequestDocumentRule extends MaintenanceDocumentRuleBase {
                     }
                 }
             }
+        if(oleDeliverRequestBo.getRequestExpiryDate()!= null && oleDeliverRequestBo.getRequestExpiryDate().compareTo(oldDeliverRequestBo.getRequestExpiryDate())!=0) {
+            if (oleDeliverRequestBo.getDeliverNotices() != null) {
+                for (OLEDeliverNotice oleDeliverNotice : oleDeliverRequestBo.getDeliverNotices()) {
+                    if (oleDeliverNotice.getNoticeType().equals(OLEConstants.REQUEST_EXPIRATION_NOTICE)) {
+                        oleDeliverNotice.setNoticeToBeSendDate(new Timestamp(oleDeliverRequestBo.getRequestExpiryDate().getTime()));
+                    }
+                }
+            }
+        }
         return processed;
     }
 }


### PR DESCRIPTION
OLE-9409 : Updating request expiration date fails to update the notice send date for request expiration notices