### PR TITLE
OLE-9409 : Updating request expiration date fails to update the notice send date for request expiration notices

### DIFF
--- a/ole-app/olefs/src/main/java/org/kuali/ole/deliver/rule/OleDeliverRequestDocumentRule.java
+++ b/ole-app/olefs/src/main/java/org/kuali/ole/deliver/rule/OleDeliverRequestDocumentRule.java
@@ -207,7 +207,9 @@ public class OleDeliverRequestDocumentRule extends MaintenanceDocumentRuleBase {
                     }
                 }
             }
-        if(oleDeliverRequestBo.getRequestExpiryDate()!= null && oleDeliverRequestBo.getRequestExpiryDate().compareTo(oldDeliverRequestBo.getRequestExpiryDate())!=0) {
+            if((oleDeliverRequestBo.getRequestExpiryDate()!= null && oldDeliverRequestBo.getRequestExpiryDate() == null) ||
+                 ((oleDeliverRequestBo.getRequestExpiryDate()!= null && oldDeliverRequestBo.getRequestExpiryDate() != null) && 
+                 	oleDeliverRequestBo.getRequestExpiryDate().compareTo(oldDeliverRequestBo.getRequestExpiryDate())!=0)) {
             if (oleDeliverRequestBo.getDeliverNotices() != null) {
                 for (OLEDeliverNotice oleDeliverNotice : oleDeliverRequestBo.getDeliverNotices()) {
                     if (oleDeliverNotice.getNoticeType().equals(OLEConstants.REQUEST_EXPIRATION_NOTICE)) {


### PR DESCRIPTION
OLE-9409 : Updating request expiration date fails to update the notice send date for request expiration notices